### PR TITLE
Add "allow multi currency" option

### DIFF
--- a/spec/Action/ConvertPaymentActionSpec.php
+++ b/spec/Action/ConvertPaymentActionSpec.php
@@ -18,17 +18,26 @@ use Payum\Core\Action\ActionInterface;
 use Payum\Core\GatewayInterface;
 use Payum\Core\Request\Convert;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Sylius\Bundle\PayumBundle\Provider\PaymentDescriptionProviderInterface;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\AddressInterface;
+use Sylius\Component\Core\Model\Channel;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Currency\Model\Currency;
 
 final class ConvertPaymentActionSpec extends ObjectBehavior
 {
-    function let(PaymentDescriptionProviderInterface $paymentDescriptionProvider): void
+    function let(PaymentDescriptionProviderInterface $paymentDescriptionProvider, ChannelContextInterface $channelContext): void
     {
-        $this->beConstructedWith($paymentDescriptionProvider);
+        $eur = new Currency();
+        $eur->setCode('EUR');
+        $channel = new Channel();
+        $channel->setBaseCurrency($eur);
+        $channelContext->getChannel(Argument::any())->willReturn($channel);
+        $this->beConstructedWith($paymentDescriptionProvider, $channelContext);
     }
 
     function it_is_initializable(): void
@@ -55,6 +64,7 @@ final class ConvertPaymentActionSpec extends ObjectBehavior
         $this->setApi($multiSafepayApiClient);
 
         $multiSafepayApiClient->getType()->willReturn(MultiSafepayApiClientInterface::REDIRECT_ORDER_TYPE);
+        $multiSafepayApiClient->getAllowMultiCurrency()->willReturn(false);
         $order->getId()->willReturn(21);
         $request->getSource()->willReturn($payment);
         $request->getTo()->willReturn('array');

--- a/src/Action/ConvertPaymentAction.php
+++ b/src/Action/ConvertPaymentAction.php
@@ -27,6 +27,7 @@ use Sylius\Component\Core\Model\Channel;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Currency\Model\CurrencyInterface;
 
 final class ConvertPaymentAction implements ActionInterface, GatewayAwareInterface, ApiAwareInterface
 {
@@ -65,7 +66,10 @@ final class ConvertPaymentAction implements ActionInterface, GatewayAwareInterfa
 
         /** @var Channel $currentChannel */
         $currentChannel = $this->channelContext->getChannel();
-        $currency = ($this->multiSafepayApiClient->getAllowMultiCurrency()) ? $order->getCurrencyCode() : $currentChannel->getBaseCurrency()->getCode();
+
+        /** @var CurrencyInterface $baseCurrency */
+        $baseCurrency = $currentChannel->getBaseCurrency();
+        $currency = ($this->multiSafepayApiClient->getAllowMultiCurrency()) ? $order->getCurrencyCode() : $baseCurrency->getCode();
 
         $details = ArrayObject::ensureArrayObject($payment->getDetails());
         $details['paymentData'] = [

--- a/src/Action/ConvertPaymentAction.php
+++ b/src/Action/ConvertPaymentAction.php
@@ -62,7 +62,7 @@ final class ConvertPaymentAction implements ActionInterface, GatewayAwareInterfa
         /** @var AddressInterface $billingAddress */
         $billingAddress = $order->getBillingAddress();
 
-        $currency = ($this->multiSafepayApiClient->getAllowMultiCurrency()) ? $order->getCurrencyCode() : $this->channelContext->getChannel()->getBaseCurrency();
+        $currency = ($this->multiSafepayApiClient->getAllowMultiCurrency()) ? $order->getCurrencyCode() : $this->channelContext->getChannel()->getBaseCurrency()->getCode();
 
         $details = ArrayObject::ensureArrayObject($payment->getDetails());
         $details['paymentData'] = [

--- a/src/Action/ConvertPaymentAction.php
+++ b/src/Action/ConvertPaymentAction.php
@@ -23,6 +23,7 @@ use Payum\Core\Request\Convert;
 use Sylius\Bundle\PayumBundle\Provider\PaymentDescriptionProviderInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\AddressInterface;
+use Sylius\Component\Core\Model\Channel;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
@@ -62,7 +63,9 @@ final class ConvertPaymentAction implements ActionInterface, GatewayAwareInterfa
         /** @var AddressInterface $billingAddress */
         $billingAddress = $order->getBillingAddress();
 
-        $currency = ($this->multiSafepayApiClient->getAllowMultiCurrency()) ? $order->getCurrencyCode() : $this->channelContext->getChannel()->getBaseCurrency()->getCode();
+        /** @var Channel $currentChannel */
+        $currentChannel = $this->channelContext->getChannel();
+        $currency = ($this->multiSafepayApiClient->getAllowMultiCurrency()) ? $order->getCurrencyCode() : $currentChannel->getBaseCurrency()->getCode();
 
         $details = ArrayObject::ensureArrayObject($payment->getDetails());
         $details['paymentData'] = [

--- a/src/ApiClient/MultiSafepayApiClient.php
+++ b/src/ApiClient/MultiSafepayApiClient.php
@@ -23,12 +23,15 @@ class MultiSafepayApiClient implements MultiSafepayApiClientInterface
     /** @var string */
     private $type;
 
-    public function initialise(string $apiKey, string $type, bool $sandbox = true): void
+    /** @var bool */
+    private $allowMultiCurrency;
+
+    public function initialise(string $apiKey, string $type, bool $sandbox = true, bool $allowMultiCurrency = false): void
     {
         $this->type = $type;
+        $this->allowMultiCurrency = $allowMultiCurrency;
 
         $this->client = new Client();
-
         $this->client->setApiKey($apiKey);
         $this->client->setApiUrl(
             $sandbox ? self::API_URL_TEST : self::API_URL_LIVE
@@ -50,6 +53,11 @@ class MultiSafepayApiClient implements MultiSafepayApiClientInterface
     public function getType(): string
     {
         return $this->type;
+    }
+
+    public function getAllowMultiCurrency(): bool
+    {
+        return $this->allowMultiCurrency;
     }
 
     public function refund(string $orderId, int $amount, string $currencyCode): void

--- a/src/ApiClient/MultiSafepayApiClientInterface.php
+++ b/src/ApiClient/MultiSafepayApiClientInterface.php
@@ -44,7 +44,7 @@ interface MultiSafepayApiClientInterface
 
     public const STATUS_VOID = 'void';
 
-    public function initialise(string $apiKey, string $type, bool $sandbox = true): void;
+    public function initialise(string $apiKey, string $type, bool $sandbox = true, bool $allowMultiCurrency = false): void;
 
     public function createPayment(array $data): Orders;
 
@@ -55,4 +55,6 @@ interface MultiSafepayApiClientInterface
     public function refund(string $orderId, int $amount, string $currencyCode): void;
 
     public function isPaymentActive(string $status): bool;
+
+    public function getAllowMultiCurrency(): bool;
 }

--- a/src/Form/Type/MultiSafepayGatewayConfigurationType.php
+++ b/src/Form/Type/MultiSafepayGatewayConfigurationType.php
@@ -39,6 +39,9 @@ final class MultiSafepayGatewayConfigurationType extends AbstractType
             ->add('sandbox', CheckboxType::class, [
                 'label' => 'bitbag_sylius_multisafepay.ui.sandbox',
             ])
+            ->add('allow_multi_currency', CheckboxType::class, [
+                'label' => 'bitbag_sylius_multisafepay.ui.allow_multi_currency',
+            ])
             ->add('type', ChoiceType::class, [
                 'label' => 'bitbag_sylius_multisafepay.ui.type',
                 'choices' => [

--- a/src/MultiSafepayGatewayFactory.php
+++ b/src/MultiSafepayGatewayFactory.php
@@ -33,6 +33,7 @@ final class MultiSafepayGatewayFactory extends GatewayFactory
                 'apiKey' => null,
                 'sandbox' => true,
                 'type' => null,
+                'allow_multi_currency' => false,
             ];
 
             $config->defaults($config['payum.default_options']);
@@ -40,6 +41,7 @@ final class MultiSafepayGatewayFactory extends GatewayFactory
             $config['payum.required_options'] = [
                 'apiKey',
                 'type',
+                'allow_multi_currency',
             ];
 
             $config['payum.api'] = function (ArrayObject $config): MultiSafepayApiClientInterface {
@@ -47,8 +49,7 @@ final class MultiSafepayGatewayFactory extends GatewayFactory
 
                 /** @var MultiSafepayApiClientInterface $multiSafepayApiClient */
                 $multiSafepayApiClient = $config['payum.http_client'];
-
-                $multiSafepayApiClient->initialise($config['apiKey'], $config['type'], $config['sandbox']);
+                $multiSafepayApiClient->initialise($config['apiKey'], $config['type'], $config['sandbox'], $config['allow_multi_currency']);
 
                 return $multiSafepayApiClient;
             };

--- a/src/MultiSafepayGatewayFactory.php
+++ b/src/MultiSafepayGatewayFactory.php
@@ -41,7 +41,6 @@ final class MultiSafepayGatewayFactory extends GatewayFactory
             $config['payum.required_options'] = [
                 'apiKey',
                 'type',
-                'allow_multi_currency',
             ];
 
             $config['payum.api'] = function (ArrayObject $config): MultiSafepayApiClientInterface {

--- a/src/Resources/config/services/action.xml
+++ b/src/Resources/config/services/action.xml
@@ -15,6 +15,7 @@
 
         <service id="bitbag_sylius_multisafepay_plugin.action.convert_payment" class="BitBag\SyliusMultiSafepayPlugin\Action\ConvertPaymentAction">
             <argument type="service" id="sylius.payment_description_provider" />
+            <argument type="service" id="sylius.context.channel" />
             <tag name="payum.action" factory="multisafepay" alias="payum.action.convert_payment" />
         </service>
 

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -6,3 +6,4 @@ bitbag_sylius_multisafepay:
         payment_link: Payment link
         redirect_order: Redirect order
         sandbox: Sandbox
+        allow_multi_currency: Allow multi currency payments

--- a/tests/Behat/Context/Setup/MultiSafepayContext.php
+++ b/tests/Behat/Context/Setup/MultiSafepayContext.php
@@ -70,6 +70,7 @@ final class MultiSafepayContext implements Context
         $paymentMethod->getGatewayConfig()->setConfig([
             'apiKey' => 'test',
             'sandbox' => true,
+            'allow_multi_currency' => false,
             'payum.http_client' => '@bitbag_sylius_multisafepay_plugin.api_client.multisafepay_api_client',
             'type' => MultiSafepayApiClientInterface::REDIRECT_ORDER_TYPE,
         ]);

--- a/tests/Behat/Mocker/MultiSafepayApiClient.php
+++ b/tests/Behat/Mocker/MultiSafepayApiClient.php
@@ -36,12 +36,18 @@ class MultiSafepayApiClient implements MultiSafepayApiClientInterface
         return $this->container->get('bitbag_sylius_multisafepay_plugin.api_client.multisafepay_api_client')->getType();
     }
 
-    public function initialise(string $apiKey, string $type, bool $sandbox = true): void
+    public function getAllowMultiCurrency(): bool
+    {
+        return $this->container->get('bitbag_sylius_multisafepay_plugin.api_client.multisafepay_api_client')->getAllowMultiCurrency();
+    }
+
+    public function initialise(string $apiKey, string $type, bool $sandbox = true,  bool $allowMultiCurrency = false): void
     {
         $this->container->get('bitbag_sylius_multisafepay_plugin.api_client.multisafepay_api_client')->initialise(
             $apiKey,
             $type,
-            $sandbox
+            $sandbox,
+            $allowMultiCurrency
         );
     }
 

--- a/tests/Behat/Mocker/MultiSafepayApiClientMocker.php
+++ b/tests/Behat/Mocker/MultiSafepayApiClientMocker.php
@@ -37,6 +37,10 @@ final class MultiSafepayApiClientMocker
             ->shouldReceive('initialise')
         ;
 
+        $mock
+            ->shouldReceive('getAllowMultiCurrency')
+        ;
+
         $orders = \Mockery::mock('orders', Orders::class);
 
         $orders
@@ -118,6 +122,10 @@ final class MultiSafepayApiClientMocker
 
         $mock
             ->shouldReceive('initialise')
+        ;
+
+        $mock
+            ->shouldReceive('getAllowMultiCurrency')
         ;
 
         $action();


### PR DESCRIPTION
This is a security feature.

"allow multi currency" is a checkbox and by default false. 
When off,  the base currency of the channel is used.
When on, Orders currency is used (actual default)

For our non 'euro' clients we uses the multi currency feature of Sylius but _just for display_
and for the record 300 Japanese yen is **not** 300 euros (true story)

Also enable multi currency payments is maybe more of a financial's decision than a developer's 
